### PR TITLE
Configurable file readers

### DIFF
--- a/docs/source/config_options.rst
+++ b/docs/source/config_options.rst
@@ -190,12 +190,33 @@ In order to configure custom properties for this reader, the name you must use i
   * Default: 4096
   * Importance: medium
 
+``file_reader.sequence.field_name.key``
+  Custom field name for the output key to include in the Kafka message.
+
+  * Type: string
+  * Default: key
+  * Importance: low
+
+``file_reader.sequence.field_name.value``
+  Custom field name for the output value to include in the Kafka message.
+
+  * Type: string
+  * Default: value
+  * Importance: low
+
 .. _config_options-filereaders-text:
 
 Text
 --------------------------------------------
 
-This reader does not have any additional configuration.
+In order to configure custom properties for this reader, the name you must use is ``text``.
+
+``file_reader.text.field_name.value``
+  Custom field name for the output value to include in the Kafka message.
+
+  * Type: string
+  * Default: value
+  * Importance: low
 
 .. _config_options-filereaders-delimited:
 

--- a/docs/source/filereaders.rst
+++ b/docs/source/filereaders.rst
@@ -29,7 +29,8 @@ SequenceFile
 the Hadoop file formats which are serialized in key/value pairs.
 
 This reader can process this file format and build a Kafka message with the
-key/value pair. These two values are named ``key`` and ``value`` in the message.
+key/value pair. These two values are named ``key`` and ``value`` in the message
+by default but you can customize these field names.
 
 More information about properties of this file reader
 :ref:`here<config_options-filereaders-sequencefile>`.
@@ -40,7 +41,8 @@ Text
 Read plain text files.
 
 Each line represents one record which will be in a field
-named ``value`` in the message sent to Kafka.
+named ``value`` in the message sent to Kafka by default but you can
+customize these field names.
 
 Delimited text
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.mmolimar.kafka.connect</groupId>
     <artifactId>kafka-connect-fs</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.1.1</version>
     <packaging>jar</packaging>
 
     <name>kafka-connect-fs</name>

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AvroFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/AvroFileReader.java
@@ -88,8 +88,8 @@ public class AvroFileReader extends AbstractFileReader<GenericRecord> {
     }
 
     static class GenericRecordToStruct implements ReaderAdapter<GenericRecord> {
-        static final int CACHE_SIZE = 100;
-        AvroData avroData;
+        private static final int CACHE_SIZE = 100;
+        private final AvroData avroData;
 
         public GenericRecordToStruct() {
             this.avroData = new AvroData(CACHE_SIZE);

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/DelimitedTextFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/DelimitedTextFileReader.java
@@ -33,7 +33,7 @@ public class DelimitedTextFileReader extends AbstractFileReader<DelimitedTextFil
 
         SchemaBuilder schemaBuilder = SchemaBuilder.struct();
         if (hasNext()) {
-            String firstLine = inner.nextRecord();
+            String firstLine = inner.nextRecord().getValue();
             String columns[] = firstLine.split(token);
             IntStream.range(0, columns.length).forEach(index -> {
                 String columnName = hasHeader ? columns[index] : DEFAULT_COLUMN_NAME + "_" + ++index;
@@ -61,7 +61,7 @@ public class DelimitedTextFileReader extends AbstractFileReader<DelimitedTextFil
     @Override
     protected DelimitedRecord nextRecord() {
         offset.inc();
-        return new DelimitedRecord(schema, inner.nextRecord().split(token));
+        return new DelimitedRecord(schema, inner.nextRecord().getValue().split(token));
     }
 
     @Override
@@ -123,8 +123,8 @@ public class DelimitedTextFileReader extends AbstractFileReader<DelimitedTextFil
     }
 
     static class DelimitedRecord {
-        final Schema schema;
-        final String[] values;
+        private final Schema schema;
+        private final String[] values;
 
         public DelimitedRecord(Schema schema, String[] values) {
             this.schema = schema;

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
@@ -119,8 +119,8 @@ public class ParquetFileReader extends AbstractFileReader<GenericRecord> {
     }
 
     static class GenericRecordToStruct implements ReaderAdapter<GenericRecord> {
-        static final int CACHE_SIZE = 100;
-        AvroData avroData;
+        private static final int CACHE_SIZE = 100;
+        private final AvroData avroData;
 
         public GenericRecordToStruct() {
             this.avroData = new AvroData(CACHE_SIZE);

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/SequenceFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/SequenceFileReaderTest.java
@@ -10,25 +10,31 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 public class SequenceFileReaderTest extends HdfsFileReaderTestBase {
 
-    private static final String FIELD_KEY = "key";
-    private static final String FIELD_VALUE = "value";
+    private static final String FIELD_NAME_KEY = "key";
+    private static final String FIELD_NAME_VALUE = "value";
 
     @BeforeClass
     public static void setUp() throws IOException {
         readerClass = SequenceFileReader.class;
         dataFile = createDataFile();
-        readerConfig = new HashMap<>();
+        readerConfig = new HashMap<String, Object>() {{
+            put(SequenceFileReader.FILE_READER_SEQUENCE_FIELD_NAME_KEY, FIELD_NAME_KEY);
+            put(SequenceFileReader.FILE_READER_SEQUENCE_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
+        }};
     }
 
     private static Path createDataFile() throws IOException {
@@ -63,6 +69,23 @@ public class SequenceFileReaderTest extends HdfsFileReaderTestBase {
         return path;
     }
 
+    @Test
+    public void defaultFieldNames() throws Throwable {
+        Map<String, Object> customReaderCfg = new HashMap<String, Object>();
+        reader = getReader(fs, dataFile, customReaderCfg);
+        assertTrue(reader.getFilePath().equals(dataFile));
+
+        assertTrue(reader.hasNext());
+
+        int recordCount = 0;
+        while (reader.hasNext()) {
+            Struct record = reader.next();
+            checkData(SequenceFileReader.FIELD_NAME_KEY_DEFAULT, SequenceFileReader.FIELD_NAME_VALUE_DEFAULT, record, recordCount);
+            recordCount++;
+        }
+        assertEquals("The number of records in the file does not match", NUM_RECORDS, recordCount);
+    }
+
     @Override
     protected Offset getOffset(long offset) {
         return new SequenceFileReader.SeqOffset(offset);
@@ -70,7 +93,11 @@ public class SequenceFileReaderTest extends HdfsFileReaderTestBase {
 
     @Override
     protected void checkData(Struct record, long index) {
-        assertTrue((Integer) record.get(FIELD_KEY) == index);
-        assertTrue(record.get(FIELD_VALUE).toString().startsWith(index + "_"));
+        checkData(FIELD_NAME_KEY, FIELD_NAME_VALUE, record, index);
+    }
+
+    private void checkData(String keyFieldName, String valueFieldName, Struct record, long index) {
+        assertTrue((Integer) record.get(keyFieldName) == index);
+        assertTrue(record.get(valueFieldName).toString().startsWith(index + "_"));
     }
 }

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/TextFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/hdfs/TextFileReaderTest.java
@@ -19,13 +19,15 @@ import static org.junit.Assert.assertTrue;
 
 public class TextFileReaderTest extends HdfsFileReaderTestBase {
 
-    private static final String FIELD_VALUE = "value";
+    private static final String FIELD_NAME_VALUE = "custom_field_name";
 
     @BeforeClass
     public static void setUp() throws IOException {
         readerClass = TextFileReader.class;
         dataFile = createDataFile();
-        readerConfig = new HashMap<>();
+        readerConfig = new HashMap<String, Object>() {{
+            put(TextFileReader.FILE_READER_TEXT_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
+        }};
     }
 
     private static Path createDataFile() throws IOException {
@@ -66,6 +68,6 @@ public class TextFileReaderTest extends HdfsFileReaderTestBase {
 
     @Override
     protected void checkData(Struct record, long index) {
-        assertTrue(record.get(FIELD_VALUE).toString().startsWith(index + "_"));
+        assertTrue(record.get(FIELD_NAME_VALUE).toString().startsWith(index + "_"));
     }
 }

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/TextFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/local/TextFileReaderTest.java
@@ -19,13 +19,15 @@ import static org.junit.Assert.assertTrue;
 
 public class TextFileReaderTest extends LocalFileReaderTestBase {
 
-    private static final String FIELD_VALUE = "value";
+    private static final String FIELD_NAME_VALUE = "custom_field_name";
 
     @BeforeClass
     public static void setUp() throws IOException {
         readerClass = TextFileReader.class;
         dataFile = createDataFile();
-        readerConfig = new HashMap<>();
+        readerConfig = new HashMap<String, Object>() {{
+            put(TextFileReader.FILE_READER_TEXT_FIELD_NAME_VALUE, FIELD_NAME_VALUE);
+        }};
     }
 
     private static Path createDataFile() throws IOException {
@@ -66,6 +68,6 @@ public class TextFileReaderTest extends LocalFileReaderTestBase {
 
     @Override
     protected void checkData(Struct record, long index) {
-        assertTrue(record.get(FIELD_VALUE).toString().startsWith(index + "_"));
+        assertTrue(record.get(FIELD_NAME_VALUE).toString().startsWith(index + "_"));
     }
 }

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/task/hdfs/HdfsFsSourceTaskTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/task/hdfs/HdfsFsSourceTaskTest.java
@@ -38,7 +38,7 @@ public class HdfsFsSourceTaskTest extends HdfsFsSourceTaskTestBase {
             assertNotNull(record.sourceOffset());
             assertNotNull(record.value());
 
-            assertNotNull(((Struct) record.value()).get(TextFileReader.FIELD_VALUE));
+            assertNotNull(((Struct) record.value()).get(TextFileReader.FIELD_NAME_VALUE_DEFAULT));
         });
     }
 

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/task/local/LocalFsSourceTaskTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/task/local/LocalFsSourceTaskTest.java
@@ -38,7 +38,7 @@ public class LocalFsSourceTaskTest extends LocalFsSourceTaskTestBase {
             assertNotNull(record.sourceOffset());
             assertNotNull(record.value());
 
-            assertNotNull(((Struct) record.value()).get(TextFileReader.FIELD_VALUE));
+            assertNotNull(((Struct) record.value()).get(TextFileReader.FIELD_NAME_VALUE_DEFAULT));
         });
     }
 


### PR DESCRIPTION
Enable the option of changing the output field names when delivering records.
This PR applies to the following file readers:

- Text file reader.
- Delimited text file reader.
- Sequence file reader.