### PR TITLE
(fix): Stack Overflow error incase of long directory listing

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -138,17 +138,22 @@ abstract class AbstractPolicy implements Policy {
             @Override
             public boolean hasNext() {
                 try {
-                    if (current == null) {
-                        if (!it.hasNext()) return false;
-                        current = it.next();
-                        return hasNext();
+                    while (true) {
+                        if (current == null) {
+                            if (!it.hasNext()) {
+                                return false;
+                            } else {
+                                current = it.next();
+                            }
+                        }
+
+                        if (current.isFile() &&
+                                fileRegexp.matcher(current.getPath().getName()).find()) {
+                            return true;
+                        } else {
+                            current = null;
+                        }
                     }
-                    if (current.isFile() &&
-                            fileRegexp.matcher(current.getPath().getName()).find()) {
-                        return true;
-                    }
-                    current = null;
-                    return hasNext();
                 } catch (IOException ioe) {
                     throw new ConnectException(ioe);
                 }


### PR DESCRIPTION
Making the code iterative instead of recursive solves the issue, as jvm's general heap storage is around 512M which though can be increased, but still the recursive code can't handle the case of more than 10k call stack frames in general situations, thus making the code iterative is much cleaner way to handle this.  

**Fixes #40**