### PR TITLE
Improve performance of connector 

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -102,6 +102,7 @@ public class FsSourceTask extends SourceTask {
                     } catch (ConnectException | IOException e) {
                         //when an exception happens reading a file, the connector continues
                         log.error("Error reading file [{}]. Keep going...", metadata.getPath(), e);
+                        return new ArrayList<SourceRecord>().stream();
                     }
                     log.debug("Read [{}] records from file [{}].", records.size(), metadata.getPath());
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTaskConfig.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTaskConfig.java
@@ -32,6 +32,11 @@ public class FsSourceTaskConfig extends FsSourceConnectorConfig {
     public static final int POLL_INTERVAL_MS_DEFAULT = 10000;
     private static final String POLL_INTERVAL_MS_DISPLAY = "Poll Interval (ms)";
 
+    public static final String FILES_CHUNK_SIZE = "files.chunk.size";
+    private static final String FILES_CHUNK_SIZE_DOC = "The number of files that will be be chunked together for grabbing offsets from kafka connect.  Tune this value for higher throughput if you notice a delay between processing files.";
+    public static final  int FILES_CHUNK_SIZE_DEFAULT = 20;
+    private static final String FILES_CHUNK_SIZE_DISPLAY = "Files chunk size";
+
     private static final String POLICY_GROUP = "Policy";
     private static final String CONNECTOR_GROUP = "Connector";
 
@@ -96,6 +101,16 @@ public class FsSourceTaskConfig extends FsSourceConnectorConfig {
                         ++order,
                         ConfigDef.Width.SHORT,
                         POLL_INTERVAL_MS_DISPLAY
+                ).define(
+                        FILES_CHUNK_SIZE,
+                        ConfigDef.Type.INT,
+                        FILES_CHUNK_SIZE_DEFAULT,
+                        ConfigDef.Importance.MEDIUM,
+                        FILES_CHUNK_SIZE_DOC,
+                        CONNECTOR_GROUP,
+                        ++order,
+                        ConfigDef.Width.MEDIUM,
+                        FILES_CHUNK_SIZE_DISPLAY
                 );
     }
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -8,12 +8,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public interface Policy extends Closeable {
 
     Iterator<FileMetadata> execute() throws IOException;
 
-    FileReader offer(FileMetadata metadata, OffsetStorageReader offsetStorageReader) throws IOException;
+    FileReader offer(FileMetadata metadata, Map<String, Object> offset) throws IOException;
 
     boolean hasEnded();
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/util/IteratorUtils.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/util/IteratorUtils.java
@@ -1,0 +1,34 @@
+package com.github.mmolimar.kafka.connect.fs.util;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class IteratorUtils {
+    public static <T> Iterator<List<T>> chunkIterator(Iterator<T> iterator, int elementsPerChunk){
+        if(elementsPerChunk <= 0){
+            throw new IllegalArgumentException(String.format("elementsPerChunk must be greater than 0 but was set to %d", elementsPerChunk));
+        }
+        return new Iterator<List<T>>() {
+
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            public List<T> next() {
+                List<T> result = new ArrayList<>(elementsPerChunk);
+                for (int i = 0; i < elementsPerChunk && iterator.hasNext(); i++) {
+                    result.add(iterator.next());
+                }
+                return result;
+            }
+        };
+    }
+
+    public static <T> Stream<T> asStream(Iterator<T> src) {
+        Iterable<T> iterable = () -> src;
+        return StreamSupport.stream(iterable.spliterator(), false);
+    }
+}

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/util/IteratorUtilsTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/util/IteratorUtilsTest.java
@@ -78,6 +78,17 @@ public class IteratorUtilsTest {
     }
 
     @Test
+    public void testIteratorChunkingWithEmptyIteratorWorks() {
+        Iterator<Integer> iterator = IntStream.range(0, 0).boxed().iterator();
+        Iterator<List<Integer>> chunkedIterator = IteratorUtils.chunkIterator(iterator, 5);
+
+        List<List<Integer>> materializedChunkedIterator  = asStream(chunkedIterator).collect(Collectors.toList());
+        ArrayList<ArrayList<Integer>> expected = new ArrayList<>();
+
+        assertEquals(expected, materializedChunkedIterator);
+    }
+
+    @Test
     public void testIteratorChunkingThrowsWithInvalidChunkSize() {
         Iterator<Integer> iterator = IntStream.rangeClosed(0, 2).boxed().iterator();
 

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/util/IteratorUtilsTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/util/IteratorUtilsTest.java
@@ -1,0 +1,89 @@
+package com.github.mmolimar.kafka.connect.fs.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.github.mmolimar.kafka.connect.fs.util.IteratorUtils.asStream;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class IteratorUtilsTest {
+
+    @Test
+    public void testIteratorChunkingWorks() {
+        Iterator<Integer> iterator = IntStream.rangeClosed(0, 9).boxed().iterator();
+        Iterator<List<Integer>> chunkedIterator = IteratorUtils.chunkIterator(iterator, 2);
+
+        List<List<Integer>> materializedChunkedIterator  = asStream(chunkedIterator).collect(Collectors.toList());
+        ArrayList<ArrayList<Integer>> expected = new ArrayList<ArrayList<Integer>>(){{
+            add(new ArrayList<Integer>(){{
+                add(0); add(1);
+            }});
+            add(new ArrayList<Integer>(){{
+                add(2); add(3);
+            }});
+            add(new ArrayList<Integer>(){{
+                add(4); add(5);
+            }});
+            add(new ArrayList<Integer>(){{
+                add(6); add(7);
+            }});
+            add(new ArrayList<Integer>(){{
+                add(8); add(9);
+            }});
+        }};
+
+        assertEquals(expected, materializedChunkedIterator);
+    }
+
+    @Test
+    public void testIteratorChunkingWorksWithUnevenChunks() {
+        Iterator<Integer> iterator = IntStream.rangeClosed(0, 4).boxed().iterator();
+        Iterator<List<Integer>> chunkedIterator = IteratorUtils.chunkIterator(iterator, 2);
+
+        List<List<Integer>> materializedChunkedIterator  = asStream(chunkedIterator).collect(Collectors.toList());
+        ArrayList<ArrayList<Integer>> expected = new ArrayList<ArrayList<Integer>>(){{
+            add(new ArrayList<Integer>(){{
+                add(0); add(1);
+            }});
+            add(new ArrayList<Integer>(){{
+                add(2); add(3);
+            }});
+            add(new ArrayList<Integer>(){{
+                add(4);
+            }});
+        }};
+
+        assertEquals(expected, materializedChunkedIterator);
+    }
+
+    @Test
+    public void testIteratorChunkingWithChunkGreaterThanNumElementsWorks() {
+        Iterator<Integer> iterator = IntStream.rangeClosed(0, 2).boxed().iterator();
+        Iterator<List<Integer>> chunkedIterator = IteratorUtils.chunkIterator(iterator, 5);
+
+        List<List<Integer>> materializedChunkedIterator  = asStream(chunkedIterator).collect(Collectors.toList());
+        ArrayList<ArrayList<Integer>> expected = new ArrayList<ArrayList<Integer>>(){{
+            add(new ArrayList<Integer>(){{
+                add(0); add(1); add(2);
+            }});
+        }};
+
+        assertEquals(expected, materializedChunkedIterator);
+    }
+
+    @Test
+    public void testIteratorChunkingThrowsWithInvalidChunkSize() {
+        Iterator<Integer> iterator = IntStream.rangeClosed(0, 2).boxed().iterator();
+
+        assertThrows(IllegalArgumentException.class, () -> {
+            IteratorUtils.chunkIterator(iterator, 0);
+        });
+
+    }
+}


### PR DESCRIPTION
**Description**

Makes two major changes:
1. Skips reading immutable files that have already been processed. It does this by storing the `fileSizeBytes` for each file path in kafka connect offsets and then skips processing files that exist in kafka connect offsets and have the same size (ie: they have not been modified)
2. Reads offsets in chunks/batches from kafka connect offset storage. This is because accessing kafka connect offsets through the `OffsetStorageReader` is slow. I found this out because I noticed adding (1) did not improve performance a bunch and eventually found out the offset storage reader was called once per file. 

If you dig into the kafka connect code:
https://github.com/apache/kafka/blob/trunk/connect/runtime/src/main/java/org/apache/kafka/connect/storage/OffsetStorageReaderImpl.java#L61-L142
https://github.com/apache/kafka/blob/trunk/connect/runtime/src/main/java/org/apache/kafka/connect/storage/KafkaOffsetBackingStore.java#L121-L137

```
       // This operation may be relatively (but not too) expensive since it always requires checking end offsets, even
        // if we've already read up to the end. However, it also should not be common (offsets should only be read when
        // resetting a task). Always requiring that we read to the end is simpler than trying to differentiate when it
        // is safe not to (which should only be if we *know* we've maintained ownership since the last write).
```

Which explains why this operation is slow, using the offsetstoragereader requires making network requests to check we are at the end of the offsets topic. So by batching the offset reader requests into chunks, we make a lot less network requests. 

We did some internal performance testing at SpotHero, but I didn't create a performance testing benchmark.

Where before we had 20-30minutes+ of time between messages being produced, now you can see messages are being produced within a few minutes (the time between the peaks is the amount of time it takes for a polling loop).

(old):
<img width="540" alt="Screen Shot 2020-05-21 at 11 02 43 AM" src="https://user-images.githubusercontent.com/43971820/82578910-a836ab00-9b52-11ea-9a2d-a878d5ce7030.png">


(new):
<img width="550" alt="Screen Shot 2020-05-21 at 11 00 23 AM" src="https://user-images.githubusercontent.com/43971820/82578685-568e2080-9b52-11ea-9873-a978c176c350.png">
