### PR TITLE
Feature/skip unchanged files

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -78,10 +78,6 @@ public class FsSourceTask extends SourceTask {
             List<SourceRecord> totalRecords = filesToProcess().map(metadata -> {
                 List<SourceRecord> records = new ArrayList<>();
                 try (FileReader reader = policy.offer(metadata, context.offsetStorageReader())) {
-                    if(reader == null){
-                        log.info("Skipping processing file {} as it is unchanged", metadata);
-                        return records;
-                    }
                     log.info("Processing records for file {}.", metadata);
                     while (reader.hasNext()) {
                         records.add(convert(metadata, reader.currentOffset() + 1, reader.next()));

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -85,7 +85,6 @@ public class FsSourceTask extends SourceTask {
                 } catch (ConnectException | IOException e) {
                     //when an exception happens reading a file, the connector continues
                     log.error("Error reading file [{}]. Keep going...", metadata.getPath(), e);
-                    return new ArrayList<SourceRecord>();
                 }
                 log.debug("Read [{}] records from file [{}].", records.size(), metadata.getPath());
 

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/EmptyFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/EmptyFileReader.java
@@ -2,24 +2,24 @@ package com.github.mmolimar.kafka.connect.fs.file.reader;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.kafka.connect.data.Struct;
 
 import java.util.Map;
 
-public class EmptyFileReader extends AbstractFileReader<Void>{
+public class EmptyFileReader extends AbstractFileReader<Void> {
     /*
     An empty file reader that will always return no records
     Used as a null object instead of returning null
      */
-    boolean closed;
+    private boolean closed;
 
     public EmptyFileReader(FileSystem fs, Path filePath, Map<String, Object> config) {
-        super(fs, filePath, new FakeReaderAdapter(), config);
+        super(fs, filePath, (Void record) -> null, config);
         this.closed = false;
     }
 
     @Override
-    protected void configure(Map<String, String> config) {}
+    protected void configure(Map<String, String> config) {
+    }
 
     @Override
     protected Void nextRecord() {
@@ -32,23 +32,16 @@ public class EmptyFileReader extends AbstractFileReader<Void>{
     }
 
     @Override
-    public void seekFile(long offset) {}
+    public void seekFile(long offset) {
+    }
 
     @Override
-    public boolean isClosed(){
+    public boolean isClosed() {
         return this.closed;
     }
 
     @Override
     public void close() {
         closed = true;
-    }
-
-    static class FakeReaderAdapter implements ReaderAdapter<Void> {
-
-        @Override
-        public Struct apply(Void record) {
-            return null;
-        }
     }
 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/EmptyFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/EmptyFileReader.java
@@ -1,0 +1,54 @@
+package com.github.mmolimar.kafka.connect.fs.file.reader;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.kafka.connect.data.Struct;
+
+import java.util.Map;
+
+public class EmptyFileReader extends AbstractFileReader<Void>{
+    /*
+    An empty file reader that will always return no records
+    Used as a null object instead of returning null
+     */
+    boolean closed;
+
+    public EmptyFileReader(FileSystem fs, Path filePath, Map<String, Object> config) {
+        super(fs, filePath, new FakeReaderAdapter(), config);
+        this.closed = false;
+    }
+
+    @Override
+    protected void configure(Map<String, String> config) {}
+
+    @Override
+    protected Void nextRecord() {
+        return null;
+    }
+
+    @Override
+    protected boolean hasNextRecord() {
+        return false;
+    }
+
+    @Override
+    public void seekFile(long offset) {}
+
+    @Override
+    public boolean isClosed(){
+        return this.closed;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    static class FakeReaderAdapter implements ReaderAdapter<Void> {
+
+        @Override
+        public Struct apply(Void record) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -7,7 +7,6 @@ import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
 import com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils;
 import com.github.mmolimar.kafka.connect.fs.util.TailCall;
 import com.google.common.collect.Iterators;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -233,10 +232,10 @@ abstract class AbstractPolicy implements Policy {
 
                 // Only new versions of kafka-connect-fs store the file size bytes
                 // If we have the byte offset, we can skip reading the entire file if the file size has not changed
-                if(fileSizeBytesObject != null) {
-                    Long byteOffset = (Long)fileSizeBytesObject;
-                    if (metadata.getLen() == byteOffset){
-                        log.info("Skipping file: file {} has byte length and byte offset of: {}", metadata.getPath(), byteOffset);
+                if (fileSizeBytesObject != null) {
+                    Long byteOffset = (Long) fileSizeBytesObject;
+                    if (metadata.getLen() == byteOffset) {
+                        log.info("Skipping file [{}] due to it was already processed.", metadata.getPath());
                         return new EmptyFileReader(current, new Path(metadata.getPath()), conf.originals());
                     }
                 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -215,7 +215,7 @@ abstract class AbstractPolicy implements Policy {
                 if(fileSizeBytesObject != null) {
                     Long byteOffset = (Long)fileSizeBytesObject;
                     if (metadata.getLen() == byteOffset){
-                        log.info("File {} has byte length and byte offset of: {}, skipping reading the file as it is unchanged since the last execution", metadata.getPath(), byteOffset);
+                        log.info("Skipping file: file {} has byte length and byte offset of: {}", metadata.getPath(), byteOffset);
                         return null;
                     }
                 }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -197,17 +198,34 @@ abstract class AbstractPolicy implements Policy {
                 .filter(fs -> metadata.getPath().startsWith(fs.getWorkingDirectory().toString()))
                 .findFirst()
                 .orElse(null);
+
+        Supplier<FileReader> makeReader = () -> ReflectionUtils.makeReader(
+                (Class<? extends FileReader>) conf.getClass(FsSourceTaskConfig.FILE_READER_CLASS),
+                current, new Path(metadata.getPath()), conf.originals()
+        );
         try {
-            FileReader reader = ReflectionUtils.makeReader(
-                    (Class<? extends FileReader>) conf.getClass(FsSourceTaskConfig.FILE_READER_CLASS),
-                    current, new Path(metadata.getPath()), conf.originals());
             Map<String, Object> partition = Collections.singletonMap("path", metadata.getPath());
             Map<String, Object> offset = offsetStorageReader.offset(partition);
             if (offset != null && offset.get("offset") != null) {
+                Object offsetObject = offset.get("offset");
+                Object fileSizeBytesObject = offset.get("fileSizeBytes");
+
+                // Only new versions of kafka-connect-fs store the file size bytes
+                // If we have the byte offset, we can skip reading the entire file if the file size has not changed
+                if(fileSizeBytesObject != null) {
+                    Long byteOffset = (Long)fileSizeBytesObject;
+                    if (metadata.getLen() == byteOffset){
+                        log.info("File {} has byte length and byte offset of: {}, skipping reading the file as it is unchanged since the last execution", metadata.getPath(), byteOffset);
+                        return null;
+                    }
+                }
+
                 log.info("Seeking to offset [{}] for file [{}].", offset.get("offset"), metadata.getPath());
-                reader.seek((Long) offset.get("offset"));
+                FileReader reader = makeReader.get();
+                reader.seek((Long) offsetObject);
+                return reader;
             }
-            return reader;
+            return makeReader.get();
         } catch (Exception e) {
             throw new ConnectException("An error has occurred when creating reader for file: " + metadata.getPath(), e);
         }

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -2,6 +2,7 @@ package com.github.mmolimar.kafka.connect.fs.policy;
 
 import com.github.mmolimar.kafka.connect.fs.FsSourceTaskConfig;
 import com.github.mmolimar.kafka.connect.fs.file.FileMetadata;
+import com.github.mmolimar.kafka.connect.fs.file.reader.EmptyFileReader;
 import com.github.mmolimar.kafka.connect.fs.file.reader.FileReader;
 import com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils;
 import com.github.mmolimar.kafka.connect.fs.util.TailCall;
@@ -216,7 +217,7 @@ abstract class AbstractPolicy implements Policy {
                     Long byteOffset = (Long)fileSizeBytesObject;
                     if (metadata.getLen() == byteOffset){
                         log.info("Skipping file: file {} has byte length and byte offset of: {}", metadata.getPath(), byteOffset);
-                        return null;
+                        return new EmptyFileReader(current, new Path(metadata.getPath()), conf.originals());
                     }
                 }
 


### PR DESCRIPTION
Breaking this PR into two: https://github.com/mmolimar/kafka-connect-fs/pull/60

This PR just contains the bits about skipping unchanged files by storing the `fileSizeBytes` in the offset. 