### PR TITLE
Chunk access to kafka connect offsets for better performance

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -213,7 +213,7 @@ abstract class AbstractPolicy implements Policy {
     }
 
     @Override
-    public FileReader offer(FileMetadata metadata, OffsetStorageReader offsetStorageReader) {
+    public FileReader offer(FileMetadata metadata, Map<String, Object> offset) {
         FileSystem current = fileSystems.stream()
                 .filter(fs -> metadata.getPath().startsWith(fs.getWorkingDirectory().toString()))
                 .findFirst()
@@ -224,8 +224,6 @@ abstract class AbstractPolicy implements Policy {
                 current, new Path(metadata.getPath()), conf.originals()
         );
         try {
-            Map<String, Object> partition = Collections.singletonMap("path", metadata.getPath());
-            Map<String, Object> offset = offsetStorageReader.offset(partition);
             if (offset != null && offset.get("offset") != null) {
                 Object offsetObject = offset.get("offset");
                 Object fileSizeBytesObject = offset.get("fileSizeBytes");

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/Policy.java
@@ -8,12 +8,13 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 public interface Policy extends Closeable {
 
     Iterator<FileMetadata> execute() throws IOException;
 
-    FileReader offer(FileMetadata metadata, OffsetStorageReader offsetStorageReader) throws IOException;
+    FileReader offer(FileMetadata metadata, Map<String, Object> offset) throws IOException;
 
     boolean hasEnded();
 


### PR DESCRIPTION
Picking up from where this other PR left off: https://github.com/mmolimar/kafka-connect-fs/pull/60

This PR fetches all the offsets of the `filesToProcess` batch at the same time instead of fetching offsets once at a time.  This greatly improves performance since each offset fetch requires making network requests to kafka.