### PR TITLE
Make makeReader run only if reading the file is necessary

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -86,7 +86,7 @@ public class FsSourceTask extends SourceTask {
             List<SourceRecord> totalRecords = filesToProcess.stream().map(metadata -> {
                 List<SourceRecord> records = new ArrayList<>();
                 Map<String, Object> partitionKey = makePartitionKey.apply(metadata);
-                try (FileReader reader = policy.offer(metadata, Optional.ofNullable(offsets.get(partitionKey)).orElse(new HashMap<>()))) {
+                try (FileReader reader = policy.offer(metadata, offsets.getOrDefault(partitionKey, new HashMap<>()))) {
                     log.info("Processing records for file {}.", metadata);
                     while (reader.hasNext()) {
                         records.add(convert(metadata, reader.currentOffset() + 1, reader.next()));

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -86,7 +86,7 @@ public class FsSourceTask extends SourceTask {
             List<SourceRecord> totalRecords = filesToProcess.stream().map(metadata -> {
                 List<SourceRecord> records = new ArrayList<>();
                 Map<String, Object> partitionKey = makePartitionKey.apply(metadata);
-                try (FileReader reader = policy.offer(metadata, offsets.getOrDefault(partitionKey, new HashMap<>()))) {
+                try (FileReader reader = policy.offer(metadata, Optional.ofNullable(offsets.get(partitionKey)).orElse(new HashMap<>()))) {
                     log.info("Processing records for file {}.", metadata);
                     while (reader.hasNext()) {
                         records.add(convert(metadata, reader.currentOffset() + 1, reader.next()));

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -85,7 +85,8 @@ public class FsSourceTask extends SourceTask {
 
             List<SourceRecord> totalRecords = filesToProcess.stream().map(metadata -> {
                 List<SourceRecord> records = new ArrayList<>();
-                try (FileReader reader = policy.offer(metadata, offsets.get(makePartitionKey.apply(metadata)))) {
+                Map<String, Object> partitionKey = makePartitionKey.apply(metadata);
+                try (FileReader reader = policy.offer(metadata, offsets.getOrDefault(partitionKey, new HashMap<>()))) {
                     log.info("Processing records for file {}.", metadata);
                     while (reader.hasNext()) {
                         records.add(convert(metadata, reader.currentOffset() + 1, reader.next()));

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/policy/AbstractPolicy.java
@@ -230,7 +230,7 @@ abstract class AbstractPolicy implements Policy {
                             reader.seek(offset);
                             return reader;
                         }
-                    }).orElse(makeReader.get());
+                    }).orElseGet(makeReader);
         } catch (Exception e) {
             throw new ConnectException("An error has occurred when creating reader for file: " + metadata.getPath(), e);
         }


### PR DESCRIPTION
Fixing the bug introduced in this commit:
https://github.com/mmolimar/kafka-connect-fs/commit/002dc7480c0cae0183bb68466bb9693518e1822c


This is really important because if we open up a filehandle for reading some hadoop filesystem implementations (like s3a) will open up a connection per file and these connections will get exhausted quickly.

This led to a bunch of errors like this:
```
[2020-06-30 20:40:45,691] ERROR Error reading file [s3a://com.spothero.data/{REDACTED}]. Keep going... (com.github.mmolimar.kafka.connect.fs.FsSourceTask)
org.apache.kafka.connect.errors.ConnectException: An error has occurred when creating reader for file: s3a://com.spothero.data/{REDACTED}
	at com.github.mmolimar.kafka.connect.fs.policy.AbstractPolicy.offer(AbstractPolicy.java:214)
	at com.github.mmolimar.kafka.connect.fs.policy.SleepyPolicy.offer(SleepyPolicy.java:11)
	at com.github.mmolimar.kafka.connect.fs.FsSourceTask.lambda$poll$1(FsSourceTask.java:88)
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:193)
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1382)
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:482)
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:472)
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:708)
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:499)
	at com.github.mmolimar.kafka.connect.fs.FsSourceTask.poll(FsSourceTask.java:100)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.poll(WorkerSourceTask.java:265)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.execute(WorkerSourceTask.java:232)
	at org.apache.kafka.connect.runtime.WorkerTask.doRun(WorkerTask.java:177)
	at org.apache.kafka.connect.runtime.WorkerTask.run(WorkerTask.java:227)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.kafka.connect.errors.ConnectException: java.io.InterruptedIOException: getFileStatus on s3a://com.spothero.data/{REDACTED}: com.amazonaws.SdkClientException: Unable to execute HTTP request: Timeout waiting for connection from pool
	at com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils.make(ReflectionUtils.java:36)
	at com.github.mmolimar.kafka.connect.fs.util.ReflectionUtils.makeReader(ReflectionUtils.java:20)
	at com.github.mmolimar.kafka.connect.fs.policy.AbstractPolicy.lambda$offer$7(AbstractPolicy.java:193)
	at com.github.mmolimar.kafka.connect.fs.policy.AbstractPolicy.offer(AbstractPolicy.java:212)
```