### PR TITLE
Use header_names instead of column_N if available

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/UnivocityFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/UnivocityFileReader.java
@@ -84,7 +84,12 @@ abstract class UnivocityFileReader<T extends CommonParserSettings<?>>
         super(fs, filePath, new UnivocityToStruct(), config);
 
         this.iterator = iterateRecords();
-        this.schema = buildSchema(this.iterator, settings.isHeaderExtractionEnabled(), config);
+        Boolean hasHeader = settings.isHeaderExtractionEnabled();
+        if (!hasHeader) {
+            String[] headers = settings.getHeaders();
+            hasHeader = headers != null && headers.length > 0;
+        }
+        this.schema = buildSchema(this.iterator, hasHeader, config);
     }
 
     private Schema buildSchema(ResultIterator<Record, ParsingContext> it, boolean hasHeader, Map<String, Object> config) {


### PR DESCRIPTION
Closes #53 

This allows `header_names` to be specified and used as the field names in the Avro schema for files that lack a header row