### PR TITLE
Limit log message to non-empty file readers

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java
@@ -89,7 +89,7 @@ public class FsSourceTask extends SourceTask {
                 Map<String, Object> partitionKey = makePartitionKey.apply(metadata);
                 Map<String, Object> offset = Optional.ofNullable(offsets.get(partitionKey)).orElse(new HashMap<>());
                 try (FileReader reader = policy.offer(metadata, offset)) {
-                    log.info("{} Processing records for file {}...", this, metadata);
+                    if (reader.hasNext()) log.info("{} Processing records for file {}...", this, metadata);
                     while (reader.hasNext()) {
                         Struct record = reader.next();
                         // TODO change FileReader interface in the next major version


### PR DESCRIPTION
This reduces the verbosity of `INFO` level logs in `FsSourceTask` from files which are being skipped by the policy or are empty. If users want to see that a file was skipped they can set their policy log level to `INFO` and if they want to see that they tried to process an empty file they can drop the log level down to `DEBUG` and they'll see the log message on [line 105](https://github.com/mmolimar/kafka-connect-fs/blob/e141293e53630dc7a373014c1b8736e3a0170a48/src/main/java/com/github/mmolimar/kafka/connect/fs/FsSourceTask.java#L105).