### PR TITLE
Allow read null and empty value from csv without providing schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -389,7 +389,7 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 </project>

--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/UnivocityFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/UnivocityFileReader.java
@@ -141,7 +141,7 @@ abstract class UnivocityFileReader<T extends CommonParserSettings<?>>
                     "' does not match the number of fields inferred in the file.");
         } else if (dataTypes.size() == 0) {
             return IntStream.range(0, headers.length)
-                    .mapToObj(index -> Schema.STRING_SCHEMA)
+                    .mapToObj(index -> strToSchema("string"))
                     .collect(Collectors.toList());
         }
         return dataTypes;

--- a/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/UnivocityFileReaderTest.java
+++ b/src/test/java/com/github/mmolimar/kafka/connect/fs/file/reader/UnivocityFileReaderTest.java
@@ -64,7 +64,7 @@ abstract class UnivocityFileReaderTest<T extends UnivocityFileReader<?>> extends
 
     @ParameterizedTest
     @MethodSource("fileSystemConfigProvider")
-    public void invaliConfigArgs(ReaderFsTestConfig fsConfig) {
+    public void invalidConfigArgs(ReaderFsTestConfig fsConfig) {
         try {
             getReaderClass().getConstructor(FileSystem.class, Path.class, Map.class)
                     .newInstance(fsConfig.getFs(), fsConfig.getDataFile(), new HashMap<String, Object>());


### PR DESCRIPTION
Hi there,

Here is my case. When I set `file_reader.delimited.settings.allow_nulls=true` but not provide schema, the connector still raises the errors about null value required field given the following csv:

```csv
id,name
1, Jack
2,
3, Pony
```

I checked schema registry and see that the type of `name` is `string`. But I want to make it nullable i.e.  `["string", "null"]` by setting `file_reader.delimited.settings.allow_nulls=true`.

After check the code, I think when `file_reader.delimited.settings.schema` is not set or is `""`, the data type of each field is `string` without respecting `file_reader.delimited.settings.allow_nulls=true`.

I made a minor change to fix it and added tests for csv and tsv file. I also updated confluent's repo to be using `https` otherwise error occurs.

`CsvFileReaderTest` and `TsvFileReaderTest`passed. I was trying to run all the tests but it seems that some tests depends on HDFS which I don't have at the moment. So sorry.

