### PR TITLE
Fix batching on ParquetFileReader

### DIFF
--- a/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
+++ b/src/main/java/com/github/mmolimar/kafka/connect/fs/file/reader/ParquetFileReader.java
@@ -90,7 +90,7 @@ public class ParquetFileReader extends AbstractFileReader<GenericRecord> {
             this.closed = false;
             setOffset(0);
         }
-        while (hasNext() && currentOffset() < offset) {
+        while (hasNextRecord() && currentOffset() < offset) {
             nextRecord();
         }
     }


### PR DESCRIPTION
fixes #100

Currently, the parquet file batcher calls `hasNext` while seeking the file, which itself checks if `seeked == true`. This leads to the filereader repeatedly reading the second batch and never completes. Using the existing `hasNextRecord` fixes this and I assume was originally intended to be used here.

This PR doesn't contain tests, sorry. To reproduce this in tests I had to replace the mocking with stubs, which broke other tests and fixing it would be a bigger change than I think this fix warrants. [Here is a commit showing what I did to reproduce](https://github.com/jakedorne/kafka-connect-fs/commit/57f719cebdea023af30cd05d6d27a4e751ed4a55).

Thanks!